### PR TITLE
Added GameExtension base for slash command

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '1.8.20'
-    id 'io.gitlab.arturbosch.detekt' version "1.22.0-RC2"
     id 'application'
 }
 
@@ -23,6 +22,7 @@ dependencies {
     implementation "io.insert-koin:koin-core:$koin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:1.8.20"
     implementation "com.kotlindiscord.kord.extensions:kord-extensions:1.5.6"
+    implementation "com.zoho:hawking:0.1.7"
 
     // Data Access
     implementation "org.jdbi:jdbi3-core:$jdbi_version"

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/Main.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/Main.kt
@@ -3,6 +3,7 @@ package uk.co.mutuallyassureddistraction.paketliga
 import com.kotlindiscord.kord.extensions.ExtensibleBot
 import com.kotlindiscord.kord.extensions.utils.env
 import dev.kord.common.entity.Snowflake
+import uk.co.mutuallyassureddistraction.paketliga.extensions.GameExtension
 import uk.co.mutuallyassureddistraction.paketliga.extensions.SlapExtension
 
 val SERVER_ID = Snowflake(
@@ -18,7 +19,8 @@ suspend fun main() {
         }
 
         extensions {
-            add(::SlapExtension)
+//            add(::SlapExtension)
+            add(::GameExtension)
         }
     }
 

--- a/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/extensions/GameExtension.kt
+++ b/src/main/kotlin/uk/co/mutuallyassureddistraction/paketliga/extensions/GameExtension.kt
@@ -1,0 +1,71 @@
+package uk.co.mutuallyassureddistraction.paketliga.extensions
+
+import com.kotlindiscord.kord.extensions.commands.Arguments
+import com.kotlindiscord.kord.extensions.commands.converters.impl.string
+import com.kotlindiscord.kord.extensions.extensions.Extension
+import com.kotlindiscord.kord.extensions.extensions.publicSlashCommand
+import com.kotlindiscord.kord.extensions.types.respond
+import com.kotlindiscord.kord.extensions.utils.env
+import com.zoho.hawking.HawkingTimeParser
+import com.zoho.hawking.datetimeparser.configuration.HawkingConfiguration
+import com.zoho.hawking.language.english.model.DatesFound
+import dev.kord.common.entity.Snowflake
+import java.time.ZoneId
+import java.util.*
+
+
+val SERVER_ID = Snowflake(
+    env("SERVER_ID").toLong()  // Get the test server ID from the env vars or a .env file
+)
+
+class GameExtension : Extension() {
+    override val name = "gameExtension"
+
+    override suspend fun setup() {
+        publicSlashCommand(::PaketGameArgs) {  // Public slash commands have public responses
+            name = "paketliga"
+            description = "Ask the bot to create a game of PKL"
+
+            // Use guild commands for testing, global ones take up to an hour to update
+            guild(SERVER_ID)
+
+            action {
+                val parser = HawkingTimeParser()
+                val referenceDate = Date()
+                val hawkingConfiguration = HawkingConfiguration()
+                hawkingConfiguration.timeZone = ZoneId.systemDefault().toString()
+
+                val startDates : DatesFound = parser.parse(arguments.startwindow, referenceDate, hawkingConfiguration, "eng")
+                val closeDates : DatesFound = parser.parse(arguments.closewindow, referenceDate, hawkingConfiguration, "eng")
+
+                // Start or end doesn't matter if we only have one date at a time
+                val startDate = startDates.parserOutputs[0].dateRange.start
+                val closeDate = closeDates.parserOutputs[0].dateRange.start
+
+                respond {
+                    content = "Okay, you've set up your time window from ${startDate.toString()} to ${closeDate.toString()}"
+                }
+
+                //TODO put the logic in try/catch and add logging?
+            }
+        }
+    }
+
+    /**
+     * Arguments for the game, basically for this extension.
+     * Planned arguments are similar to Game Entity:
+     * from user input: startWindow, closeWindow, guessesClose, gameName (optional)
+     * from impl: userId
+     */
+    inner class PaketGameArgs : Arguments() {
+        val startwindow by string {
+            name = "startwindow"
+            description = "Start window time inputted by user"
+        }
+
+        val closewindow by string {
+            name = "closewindow"
+            description = "Close window time inputted by user"
+        }
+    }
+}


### PR DESCRIPTION
(This PR is dependent on: https://github.com/OhDearMoshe/pkl/pull/8)

Added GameExtension that act as a base game-maker extension to receive slash commands.
- Using slash command to allow multiple input instead of using chat/text-based commands
- Added a new lib: https://github.com/zoho/hawking to parse natural language to time (e.g. today 8pm, tomorrow 10 am, etc)
- Right now it is only catering start and close date for tests as a base, should add more later
- TODO: might need to add try/catch and logging for exceptions

Testing in private server (not 100% sure on how to add unit tests for this):

<img width="861" alt="Screenshot 2023-04-09 at 23 55 18" src="https://user-images.githubusercontent.com/4649248/230800281-f9a4c725-bac1-4899-9a08-bd70a548a09f.png">
<img width="760" alt="Screenshot 2023-04-09 at 23 55 59" src="https://user-images.githubusercontent.com/4649248/230800283-94febe2c-f283-427a-9198-d720f1f5efb4.png">
